### PR TITLE
Support for verbatim blocks

### DIFF
--- a/main.go
+++ b/main.go
@@ -462,7 +462,14 @@ func wrapIndent(text string, width, indent int) (result string, err error) {
 			return "", sc.Err()
 		}
 
-		if cl+len(sc.Text()) > width {
+		spaceLen := 0
+		if cl > 0 {
+			// account for space between words, if there's already a word on the
+			// current line
+			spaceLen = 1
+		}
+
+		if cl+spaceLen+len(sc.Text()) > width {
 			result += "\n"
 			result += strings.Repeat(" ", indent)
 			cl = 0
@@ -470,6 +477,7 @@ func wrapIndent(text string, width, indent int) (result string, err error) {
 
 		if cl > 0 {
 			result += " "
+			cl++
 		}
 		result += sc.Text()
 		cl += len(sc.Text())

--- a/main_test.go
+++ b/main_test.go
@@ -165,3 +165,29 @@ https://forum.restic.net/t/getting-last-successful-backup-time/531
 		})
 	}
 }
+
+func TestWrapIndent(t *testing.T) {
+	var tests = []struct {
+		In     string
+		Width  int
+		Indent int
+		Out    string
+	}{
+		{"Example string", 80, 4, "Example string"},
+		{"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.", 70, 3, "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do\n   eiusmod tempor incididunt ut labore et dolore magna aliqua."},
+		{"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.", 55, 2, "Lorem ipsum dolor sit amet, consectetur adipiscing\n  elit, sed do eiusmod tempor incididunt ut labore et\n  dolore magna aliqua."},
+	}
+
+	for _, test := range tests {
+		t.Run("", func(t *testing.T) {
+			res, err := wrapIndent(test.In, test.Width, test.Indent)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := deep.Equal(res, test.Out); diff != nil {
+				t.Error(diff)
+			}
+		})
+	}
+}

--- a/main_test.go
+++ b/main_test.go
@@ -116,6 +116,27 @@ https://forum.restic.net/t/getting-last-successful-backup-time/531
 				},
 			},
 		},
+		{
+			"Security: short and terse summary\n\n```\nexample\n   with\n       random spaces\n```\n\nLast block contains just\na few\nlinks.\n\nhttps://github.com/restic/restic/issues/12345",
+			Entry{
+				Title:     "Short and terse summary",
+				Type:      "Security",
+				TypeShort: "Sec",
+				Paragraphs: []string{
+					"```\nexample\n   with\n       random spaces\n```",
+					"Last block contains just a few links.",
+				},
+				URLs: []*url.URL{
+					parseURL(t, "https://github.com/restic/restic/issues/12345"),
+				},
+				PrimaryID:  12345,
+				PrimaryURL: parseURL(t, "https://github.com/restic/restic/issues/12345"),
+				Issues:     []string{"12345"},
+				IssueURLs: []*url.URL{
+					parseURL(t, "https://github.com/restic/restic/issues/12345"),
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/main_test.go
+++ b/main_test.go
@@ -176,6 +176,7 @@ func TestWrapIndent(t *testing.T) {
 		{"Example string", 80, 4, "Example string"},
 		{"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.", 70, 3, "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do\n   eiusmod tempor incididunt ut labore et dolore magna aliqua."},
 		{"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.", 55, 2, "Lorem ipsum dolor sit amet, consectetur adipiscing\n  elit, sed do eiusmod tempor incididunt ut labore et\n  dolore magna aliqua."},
+		{"```\nexample\n   with\n       random spaces\n```", 10, 3, "```\n   example\n      with\n          random spaces\n   ```"},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Currently it is not possible to include verbatim sections in the changelog. This PR adds minimal support for basic verbatim blocks using the markdown syntax, that is blocks enclosed in triple backticks. For these blocks, spaces and newlines are kept.

The `wrapIndent` function is also adjusted to not wrap around these verbatim sections.

I've also fixed the `wrapIndent` function to actually honor the specified column limit. Previously, inserted spaces between words were not counted against the limit.

