### PR TITLE
Sort changelog entries according to their primary id

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -28,7 +28,7 @@ func TestReadFile(t *testing.T) {
 				Title:      "Subject line",
 				Type:       "Bugfix",
 				TypeShort:  "Fix",
-				PrimaryID:  "12345",
+				PrimaryID:  12345,
 				PrimaryURL: parseURL(t, "https://github.com/restic/restic/issues/12345"),
 				URLs: []*url.URL{
 					parseURL(t, "https://github.com/restic/restic/issues/12345"),
@@ -70,7 +70,7 @@ https://github.com/restic/restic/pull/666666
 					parseURL(t, "https://github.com/restic/restic/issues/12345"),
 					parseURL(t, "https://github.com/restic/restic/pull/666666"),
 				},
-				PrimaryID:  "12345",
+				PrimaryID:  12345,
 				PrimaryURL: parseURL(t, "https://github.com/restic/restic/issues/12345"),
 				Issues:     []string{"12345"},
 				IssueURLs: []*url.URL{
@@ -94,7 +94,7 @@ https://forum.restic.net/t/getting-last-successful-backup-time/531
 				Title:      "Foo bar subject",
 				Type:       "Enhancement",
 				TypeShort:  "Enh",
-				PrimaryID:  "12345",
+				PrimaryID:  12345,
 				PrimaryURL: parseURL(t, "https://github.com/restic/restic/issues/12345"),
 				Issues:     []string{"12345", "232323"},
 				IssueURLs: []*url.URL{


### PR DESCRIPTION
In restic, we prefix changelog files with `pull-` or `issue-` depending on the type of the primary issue. Together with issue IDs of different length this leads to a pretty chaotic sort order. The issue id for each type of changes should only increase, however, the unstable order can lead to few points at which the issue id decreases without an obvious reason (e.g. the enhancements in https://github.com/restic/restic/releases/tag/v0.11.0 )

This PR changes the sort order to always use the (numerical value of the) primary issue/pr id.